### PR TITLE
fix: handle 404 when running locally (resolves #7)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fs = require("fs");
 const errorOverlay = require("eleventy-plugin-error-overlay");
 
 const htmlMinifyTransform = require("./src/transforms/html-minify.js");
@@ -30,7 +31,18 @@ module.exports = function (eleventyConfig) {
     // Configure BrowserSync.
     eleventyConfig.setBrowserSyncConfig({
         ...eleventyConfig.browserSyncConfig,
-        ghostMode: false
+        ghostMode: false,
+        callbacks: {
+            ready: function (err, bs) {
+                bs.addMiddleware("*", (req, res) => {
+                    const content_404 = fs.readFileSync("dist/404.html");
+                    // Provides the 404 content without redirect.
+                    res.write(content_404);
+                    res.writeHead(404);
+                    res.end();
+                });
+            }
+        }
     });
 
     return {

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@
 
 [dev]
     command = "npm run dev"
+    port = 5000
     targetPort = 3000
     publish = "dist"
     autoLaunch = false


### PR DESCRIPTION
This PR adds BrowserSync middleware as [documented here](https://www.11ty.dev/docs/quicktips/not-found/#with-serve) so that 404 pages will be served as expected when Eleventy is being run with `eleventy --serve` and proxied by `netlify dev`. It also sets a standard port (5000) for the `netlify dev` proxied local site for consistency when running `netlify dev` (if that port is not available, you can override it, e.g. `netlify dev --port 8888` — [see here](https://cli.netlify.com/commands/dev#dev)).

### Additional Context

In response to @amb26's comment (https://github.com/inclusive-design/inverted-wordles/pull/6#discussion_r644742937):

> I don't understand why this material is integrated with the browserSync configuration rather than at top level as part of either netlify or eleventy's. The most appropriate audience for this friendly message would be the production configuration rather than only as part of the dev preview environment in which browserSync is enabled

My understanding is that Netlify's production server serves `/404.html` for any content that's not found using whatever server their platform is based on. `netlify dev` doesn't handle do this because it's proxying Eleventy's dev server to add Netlify Functions and other Netlify-specific features. The BrowserSync configuration is our way of modifying Eleventy's dev server so that it can handle 404s gracefully.