### PR TITLE
fix: do not split phrase answers (resolves #9)

### DIFF
--- a/src/js/render_wordle.js
+++ b/src/js/render_wordle.js
@@ -29,7 +29,9 @@ inverted_wordles.extractAnswers = function (answersFile) {
         counts[answer] = counts[answer] ? counts[answer] + 1 : 1;
     };
     Object.values(answersFile).forEach(function (oneAnswerRec) {
-        oneAnswerRec.answers.forEach(storeAnswer);
+        oneAnswerRec.answers.forEach(function (answer) {
+            storeAnswer(answer.trim().toLowerCase());
+        });
     });
     return Object.entries(counts).map(function (entry) {
         return {

--- a/src/js/render_wordle.js
+++ b/src/js/render_wordle.js
@@ -29,9 +29,7 @@ inverted_wordles.extractAnswers = function (answersFile) {
         counts[answer] = counts[answer] ? counts[answer] + 1 : 1;
     };
     Object.values(answersFile).forEach(function (oneAnswerRec) {
-        oneAnswerRec.answers.forEach(function (answer) {
-            answer.toLowerCase().split(" ").forEach(storeAnswer);
-        });
+        oneAnswerRec.answers.forEach(storeAnswer);
     });
     return Object.entries(counts).map(function (entry) {
         return {


### PR DESCRIPTION
This PR removes the line that splits phrases into individual words before counting.